### PR TITLE
Add fallback for empty references

### DIFF
--- a/_layouts/pathway-page.html
+++ b/_layouts/pathway-page.html
@@ -356,8 +356,18 @@ layout: default
 {% assign refs=site.data[wpid-refs] %}
 <ol>
   {% for ref in refs %}
-  <li style="padding-bottom: 10px;">{{ ref.Citation }}</li>
-      {% endfor %}
+    <li style="padding-bottom: 10px;">
+      {{ ref.Citation }}
+      {% unless ref.Citation %}
+        {{ ref.Database }}:
+        {% if ref.Database == "URL" %}
+          <a href="{{ ref.ID }}" target="_blank" class="external" rel="nofollow">{{ ref.ID }}</a>
+        {% else %}
+          {{ ref.ID }}
+        {% endif %}
+      {% endunless %}
+    </li>
+  {% endfor %}
 </ol>
 
 <!-- JAVASCRIPT -->

--- a/_layouts/pathway-page.html
+++ b/_layouts/pathway-page.html
@@ -357,15 +357,16 @@ layout: default
 <ol>
   {% for ref in refs %}
     <li style="padding-bottom: 10px;">
-      {{ ref.Citation }}
-      {% unless ref.Citation %}
+      {% if ref.Citation %}
+        {{ ref.Citation }}
+      {% else %}
         {{ ref.Database }}:
         {% if ref.Database == "URL" %}
           <a href="{{ ref.ID }}" target="_blank" class="external" rel="nofollow">{{ ref.ID }}</a>
         {% else %}
           {{ ref.ID }}
         {% endif %}
-      {% endunless %}
+      {% endif %}
     </li>
   {% endfor %}
 </ol>


### PR DESCRIPTION
If `Citation` is empty (i.e. for unsupported databases or incorrect identifiers), list the database and the ID. If the database is "URL", make the ID a link. E.g. http://127.0.0.1:4000/pathways/WP5420.html