### PR TITLE
Improve author page formatting for Eweitz

### DIFF
--- a/_authors/Eweitz.md
+++ b/_authors/Eweitz.md
@@ -1,9 +1,9 @@
 ---
 username: Eweitz
 realname: Eric Weitz
-website: https://eweitz.github.io/ideogram/gene-leads
+website: ~
 affiliation: ~
-bio: I refine pathways, and engineer them into tools for biological discovery. My contributions are mostly systematic graphical and data improvements.  Lately, I have created a number of new pathways, sourced directly from literature (https://pfocr.wikipathways.org/), and other pathway databases.  The quick and open (https://www.wikipathways.org/contribute.html) nature of WikiPathways is delightful. I also incorporate pathways into Gene Leads Ideogram (https://eweitz.github.io/ideogram/gene-leads), a reuseable web component I've been developing to enrich gene search.
+bio: <br/>I refine pathways, and engineer them into tools for biological discovery.<br/><br/>My contributions are mostly systematic graphical and data improvements.  Lately, I have created a number of new pathways, sourced directly from literature, <a href="https://pfocr.wikipathways.org" target="_blank">PFOCR</a>, and other pathway databases.  The <a href="https://www.wikipathways.org/contribute" target="_blank">quick and open</a> nature of WikiPathways is delightful.<br/><br/>I also incorporate pathways into <a href="https://eweitz.github.io/ideogram/gene-leads" target="_blank">Gene Leads Ideogram</a>, a reuseable web component I've been developing to enrich gene search.<br/><br/>---<br/>
 github: eweitz
 orcid: ~
 linkedin: ~


### PR DESCRIPTION
This refines spacing and links in https://www.wikipathways.org/authors/Eweitz, making the page a lot more readable.

[Previously](https://github.com/wikipathways/wikipathways.github.io/pull/117), links in the `bio` section were formatted as Markdown.  It wasn't clear to me how to preview that, so I merely guessed it would work as an `.md` file.  It didn't work.

Now, my `bio` uses single-line-coded HTML, with `br` tags for line breaks and `a` tags for links.  Classic works!  Kristina's suggestion to preview changes via a local Jekyll build was key.  Thanks @khanspers! 

Here's how it looks.

### Old
<img width="1512" alt="Old_poorly_formatted_author_page__WikiPathways_2024-07-13" src="https://github.com/user-attachments/assets/a6b36916-bc71-4978-89d3-a057f02d5a60">

### New
<img width="1498" alt="New_better_formatted_author_page__WikiPathways_2024-07-13" src="https://github.com/user-attachments/assets/54310700-bfcf-48e3-a9d2-ed13b73f1253">



