### PR TITLE
redirect the /index.php/Curation_Events to the new Help page

### DIFF
--- a/help.md
+++ b/help.md
@@ -6,6 +6,7 @@ redirect_from:
  - /index.php/Help:Guidelines
  - /index.php/Help:Guidelines_EditorPalette
  - /index.php/Help:DataVisualizationInCytoscape
+ - /index.php/Curation_Events
 ---
 <div style="background:#eee; padding:20px 0px 0px 50px">
 <h1>Help Topics</h1>


### PR DESCRIPTION
/index.php/Curation_Events is one of the most popular pages on the old website

@khanspers and I were discussing this today.

What do you think? Better ideas?