### PR TITLE
Update the AOP community page

### DIFF
--- a/_communities/aop.md
+++ b/_communities/aop.md
@@ -3,19 +3,19 @@ display-name: "Adverse Outcome Pathways"
 
 title: "The Adverse Outcome Pathway (AOP) Pathways"
 
-description: "This Adverse Outcome Pathway (AOP) Community is created to highlight the molecular basis of AOPs, or events in, AOPS. In general, AOPs start with a Molecular Initiating Event (MIE) caused by a stressor, followed by Key Events (KEs), that lead to an Adverse Outcome (AO). These AOPs are intended specifically for regulatory decision making and are typically stored in the AOP Knowledge Base ([AOPKB](http://aopkb.org/)). Because AOPs are simplified explanations of biological effects after the effect of a stressor they are not useful to describe and understand the molecular basis of the AOPs and not suited to do data analysis. Such analysis is needed especially for in silico risk analysis intending to lower animal use in toxicology studies. This community page was created to present this previously missing molecular level of the AOPs and get more into detail on the biological processes involved in them. The development of these molecular AOPs is relevant for the European research projects on toxicology [EU-ToxRisk](https://www.eu-toxrisk.eu/), [OpenRiskNet](https://openrisknet.org/) and [VHP4Safety](https://vhp4safety.nl/) that also funded part of the work. This community page is also featured in the latest [NAR Database Issue on WikiPathways](https://doi.org/10.1093/nar/gkaa1024)."
+description: "An Adverse Outcome Pathway describes how a stressor causes harm: a Molecular Initiating Event, then a chain of Key Events, ending in an Adverse Outcome. AOPs are written for regulatory decision making and are collected in the [AOP-Wiki](https://aopwiki.org/). The framing is deliberately simplified, which is what makes an AOP readable, and also what leaves it short of the molecular detail you need to analyse data against one. The pathways in this community add that layer back. A molecular AOP keeps the Key Events of the source AOP and attaches the molecular pathways behind them, so it can be used for enrichment analysis and data visualisation while still pointing back at the AOP it came from. The main use is in silico risk assessment, where the point is to need fewer animal studies. The concept and the first set of these pathways are described in [Martens et al. (2023), Molecular Adverse Outcome Pathways: towards the implementation of transcriptomics data in risk assessments](https://doi.org/10.1101/2023.03.02.530766). Most of the pathways here were drawn by hand. Newer ones are generated from Key Event to pathway mappings curated in the molAOP Builder and reviewed before deposit. This community page is featured in the [NAR Database Issue on WikiPathways](https://doi.org/10.1093/nar/gkaa1024)."
 
 short-description: "The Adverse Outcome Pathway Community is created to highlight the molecular basis of Adverse Outcome Pathways."
 
-reference: "[Martens M, et al. (2018) Introducing WikiPathways as a data-source to support Adverse Outcome Pathways for regulatory risk assessment of chemicals and nanomaterials. Front Genet](https://doi:10.3389/fgene.2018.00661)."
+reference: "[Martens M, et al. (2018) Introducing WikiPathways as a data-source to support Adverse Outcome Pathways for regulatory risk assessment of chemicals and nanomaterials. Front Genet](https://doi.org/10.3389/fgene.2018.00661)."
 
 logo: "../assets/img/AOP_portal.png"
 
-logo-link: "https://aop-wiki.org/"
+logo-link: "https://aopwiki.org/"
 
-support: "This project has received funding from the European Union’s Horizon 2020 research and innovation programme project [EU-ToxRisk](https://www.eu-toxrisk.eu/) under grant agreement [No. 681002](http://cordis.europa.eu/project/rcn/198787_en.html), EINFRA-22-2016 programme project [OpenRiskNet](https://openrisknet.org/) under grant agreement [No. 731075](http://cordis.europa.eu/project/rcn/206759_en.html) and [VHP4Safety](https://vhp4safety.nl/) under NWA grant no. 1292.19.272."
+support: "This work has been funded by the European Food Safety Authority under the TXG-MAP project (GP/EFSA/ED/2022/01); by the European Union's Horizon 2020 research and innovation programme through [EU-ToxRisk](https://www.eu-toxrisk.eu/) under grant agreement [No. 681002](http://cordis.europa.eu/project/rcn/198787_en.html) and the EINFRA-22-2016 project [OpenRiskNet](https://openrisknet.org/) under grant agreement [No. 731075](http://cordis.europa.eu/project/rcn/206759_en.html); and by [VHP4Safety](https://vhp4safety.nl/) under NWA grant no. 1292.19.272."
 
-contribute: "The list of pathways is not static and can be updated at any time. If you know of a pathway that should be added, please contact the administrator, Marvin Martens (marvin.martens[AT]maastrichtuniversity.nl)."
+contribute: "The list of pathways is not static and can be updated at any time. If you know of a pathway that should be added, please contact the administrator, Marvin Martens (marvin.martens[AT]maastrichtuniversity.nl), or add its identifier directly to [communities/AOP.txt](https://github.com/wikipathways/wikipathways-database/blob/main/communities/AOP.txt)."
 
 community-tag: "AOP"
 
@@ -28,8 +28,3 @@ redirect_from:
   - /index.php/Portal:AOP
 curationui: true
 ---
-        
-        
-
-     
-


### PR DESCRIPTION
Rewrites the description, cites the molecular AOP paper, adds EFSA funding to the support line, and fixes two links that do not resolve: the logo pointed at aop-wiki.org instead of aopwiki.org, and the reference DOI used an https://doi: scheme.

Also mentions communities/AOP.txt under contribute, so adding a pathway does not have to go through email.